### PR TITLE
Add SRF Storytellingdesk articles.

### DIFF
--- a/config.json
+++ b/config.json
@@ -552,6 +552,15 @@
           }
         }
       }]
-    }
+    },
+    {
+      "publication": "Schweizer Radio und Fernsehen (SRF)",
+      "twitterHandle": "srfnews",
+      "sources": [{
+        "type": "XML",
+        "format": "RSS",
+        "path": "https://www.srf.ch/news/bnf/rss/20210660"
+      }]
+    },
   ]
 }

--- a/config.json
+++ b/config.json
@@ -561,6 +561,6 @@
         "format": "RSS",
         "path": "https://www.srf.ch/news/bnf/rss/20210660"
       }]
-    },
+    }
   ]
 }


### PR DESCRIPTION
Add the RSS-Feed of SRFs (Swiss national broadcaster) visual stories.
The articles can also be found here: [https://www.srf.ch/storytelling](https://www.srf.ch/storytelling).

Unfortunately the rss-feed seems a bit antiquated. The preview-image is part of the description.
Maybe someone can still manage to add it? (`grep -oP '<img[^>]*src="\K[^"]+'`)

<img width="577" alt="image" src="https://github.com/user-attachments/assets/627e4611-3dd1-40ca-8a87-5c9beb9b4664" />
