### PR TITLE
Add contributor workflow templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a reproducible problem with the feed bot
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Description
+
+Describe the problem and the behavior you expected.
+
+## Reproduction
+
+List the steps or command needed to reproduce the problem.
+
+## Publication or source
+
+Name the affected publication and source URL when relevant.
+
+## Additional context
+
+Add relevant logs or screenshots. Remove API keys and credentials before posting.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+Describe the change and the publication or behavior it affects.
+
+## Verification
+
+List the commands you ran, such as:
+
+```bash
+npm run test --publication="Publication Name"
+npm run audit
+```
+
+## Checklist
+
+- [ ] I kept the change focused.
+- [ ] I removed API keys, credentials, and decrypted secrets.
+- [ ] I updated documentation when behavior changed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to Interactive Journalism Feed
+
+Thanks for helping improve the Interactive Journalism Feed.
+
+## Adding or updating a publication
+
+Start with `config.json` and follow the source-type documentation in `README.md`.
+
+After changing a publication, run:
+
+```bash
+npm run test --publication="Publication Name"
+npm run audit
+```
+
+The test command checks the selected feeds without posting to Bluesky. The audit command checks publication health and updates generated publication lists.
+
+## Before opening a pull request
+
+- Keep changes focused on one publication or behavior.
+- Explain the source you added or changed.
+- Include the verification commands you ran.
+- Do not commit API keys, credentials, or a decrypted `secrets.json` file.
+- Update `README.md` when the documented publication list or behavior changes.


### PR DESCRIPTION
This adds lightweight maintainer workflow files:

- `CONTRIBUTING.md` with publication contribution steps and verification commands from the README
- `.github/ISSUE_TEMPLATE/bug_report.md` for reproducible feed bot issues
- `.github/PULL_REQUEST_TEMPLATE.md` for publication changes, verification, and secret handling

This follows up on #14. I intentionally did not add or guess a license file, since that decision needs to come from the maintainer. No application code, feed data, or credentials were changed.

Verification:

- Reviewed the templates locally
- Ran `oss-signal` locally before and after; the maintainer-readiness score improved from 31 to 49 for this repository clone
